### PR TITLE
if tableName is null and connectorType is document, then not send req…

### DIFF
--- a/app/src/routes/api/v1/dataset.router.js
+++ b/app/src/routes/api/v1/dataset.router.js
@@ -73,6 +73,10 @@ class DatasetRouter {
         const method = ctx.request.method === 'DELETE' ? 'DELETE' : 'POST';
 
         try {
+            if (!dataset.tableName && connectorType === 'document') {
+                return await Promise.resolve();
+            }
+
             return await ctRegisterMicroservice.requestToMicroservice({
                 uri,
                 method,


### PR DESCRIPTION
…uest to document adapter because document adapter the tableName field is required.