### PR TITLE
Subscribable filter in GET datasets endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# 26/11/2019
+
+- Added `subscribable` boolean filter in GET /datasets endpoint.

--- a/app/src/services/dataset.service.js
+++ b/app/src/services/dataset.service.js
@@ -151,7 +151,11 @@ class DatasetService {
                 query.userId = Object.assign({}, query.userId || {}, query[param]);
             } else if (param === 'subscribable') {
                 logger.debug('Applying subscribable filter', query[param]);
-                query.subscribable = query[param] ? { $exists: true, $nin: [false, {}] } : {};
+                if (query[param] === 'true') {
+                    query.subscribable = { $exists: true, $nin: [null, false, {}] };
+                } else if (query[param] === 'false') {
+                    query.subscribable = { $in: [null, false, {}] };
+                }
             }
         });
         if (ids.length > 0 || collection || favourite) {

--- a/app/src/services/dataset.service.js
+++ b/app/src/services/dataset.service.js
@@ -108,7 +108,7 @@ class DatasetService {
         Object.keys(query).forEach((param) => {
             if (datasetAttributes.indexOf(param) < 0 && param !== 'usersRole') {
                 delete query[param];
-            } else if (param !== 'env' && param !== 'userId' && param !== 'usersRole') {
+            } else if (param !== 'env' && param !== 'userId' && param !== 'usersRole' && param !== 'subscribable') {
                 switch (Dataset.schema.paths[param].instance) {
 
                     case 'String':
@@ -149,6 +149,9 @@ class DatasetService {
             } else if (param === 'userId') {
                 logger.debug('params userid', query[param]);
                 query.userId = Object.assign({}, query.userId || {}, query[param]);
+            } else if (param === 'subscribable') {
+                logger.debug('Applying subscribable filter', query[param]);
+                query.subscribable = query[param] ? { $exists: true, $nin: [false, {}] } : {};
             }
         });
         if (ids.length > 0 || collection || favourite) {


### PR DESCRIPTION
Related with the following PT task:

- https://www.pivotaltracker.com/story/show/168838958

This PR adds the possibility of filtering the results of the `GET dataset` endpoint, as specified in the task mentioned above.