### PR TITLE
Sort datasets by user role or name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - NODE_ENV=test
     - PORT=5037
     - API_VERSION=v1
+    - CT_REGISTER_MODE=auto
     - LOCAL_URL=http://127.0.0.1:3001
     - CT_URL=http://127.0.0.1:9000
     - MONGO_PORT_27017_TCP_ADDR=127.0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 04/12/2019   
+# 27/02/2020
+
+- Add possibility of sorting datasets by user fields (such as name or role).
+
+# 04/12/2019
 - Allow microservices to update the dataset's `errorMessage` field
 
 # 26/11/2019

--- a/app/src/models/dataset.model.js
+++ b/app/src/models/dataset.model.js
@@ -99,6 +99,8 @@ const Dataset = new Schema({
     widgetRelevantProps: [{ type: String, required: false, trim: true }],
     layerRelevantProps: [{ type: String, required: false, trim: true }],
     dataLastUpdated: { type: Date },
+    userRole: { type: String, default: null, select: false },
+    userName: { type: String, default: null, select: false },
     createdAt: { type: Date, default: Date.now },
     updatedAt: { type: Date, default: Date.now }
 });

--- a/app/src/routes/api/v1/dataset.router.js
+++ b/app/src/routes/api/v1/dataset.router.js
@@ -263,7 +263,8 @@ class DatasetRouter {
         try {
             if (query.sort && (query.sort.includes('user.role') || query.sort.includes('user.name'))) {
                 logger.debug('Detected sorting by user role or name');
-                if (!user || !['ADMIN', 'SUPERADMIN'].includes(user && user.role)) {
+                const isAdmin = ['ADMIN', 'SUPERADMIN'].includes(user && user.role);
+                if (!user || !isAdmin) {
                     ctx.throw(403, 'Sorting by user name or role not authorized.');
                     return;
                 }

--- a/app/src/routes/api/v1/dataset.router.js
+++ b/app/src/routes/api/v1/dataset.router.js
@@ -279,9 +279,9 @@ class DatasetRouter {
                 )));
             }
 
-            if (query['page[size]'] && query['page[size]'] > 100) {
-                ctx.throw(400, 'Invalid page size');
-            }
+            // if (query['page[size]'] && query['page[size]'] > 100) {
+            //     ctx.throw(400, 'Invalid page size');
+            // }
 
             if (Object.keys(query).find(el => el.indexOf('vocabulary[') >= 0)) {
                 ctx.query.ids = await RelationshipsService.filterByVocabularyTag(query);

--- a/app/src/routes/api/v1/dataset.router.js
+++ b/app/src/routes/api/v1/dataset.router.js
@@ -272,7 +272,10 @@ class DatasetRouter {
                 const users = await RelationshipsService.getUsersInfoByIds(ids);
                 await Promise.all(users.map(u => DatasetModel.updateMany(
                     { userId: u._id },
-                    { userRole: u.role, userName: u.name },
+                    {
+                        userRole: u.role ? u.role.toLowerCase() : '',
+                        userName: u.name ? u.name.toLowerCase() : '',
+                    },
                 )));
             }
 

--- a/app/src/routes/api/v1/dataset.router.js
+++ b/app/src/routes/api/v1/dataset.router.js
@@ -279,6 +279,10 @@ class DatasetRouter {
                 )));
             }
 
+            /**
+             * We'll want to limit the maximum page size in the future
+             * However, as this will cause a production BC break, we can't enforce it just now
+             */
             // if (query['page[size]'] && query['page[size]'] > 100) {
             //     ctx.throw(400, 'Invalid page size');
             // }

--- a/app/src/routes/api/v1/dataset.router.js
+++ b/app/src/routes/api/v1/dataset.router.js
@@ -268,13 +268,18 @@ class DatasetRouter {
                     ctx.throw(403, 'Sorting by user name or role not authorized.');
                     return;
                 }
+
+                // Reset all datasets' sorting columns
+                await DatasetModel.updateMany({}, { userRole: '', userName: '' });
+
+                // Fetch info to sort again
                 const ids = await DatasetService.getAllDatasetUserIds();
                 const users = await RelationshipsService.getUsersInfoByIds(ids);
                 await Promise.all(users.map(u => DatasetModel.updateMany(
                     { userId: u._id },
                     {
-                        userRole: u.role ? u.role.toLowerCase() : '',
-                        userName: u.name ? u.name.toLowerCase() : '',
+                        userRole: u.role ? u.role.toLowerCase() : '',
+                        userName: u.name ? u.name.toLowerCase() : '',
                     },
                 )));
             }

--- a/app/src/routes/api/v1/dataset.router.js
+++ b/app/src/routes/api/v1/dataset.router.js
@@ -279,6 +279,10 @@ class DatasetRouter {
                 )));
             }
 
+            if (query['page[size]'] && query['page[size]'] > 100) {
+                ctx.throw(400, 'Invalid page size');
+            }
+
             if (Object.keys(query).find(el => el.indexOf('vocabulary[') >= 0)) {
                 ctx.query.ids = await RelationshipsService.filterByVocabularyTag(query);
                 logger.debug('Ids from vocabulary-tag', ctx.query.ids);

--- a/app/src/services/dataset.service.js
+++ b/app/src/services/dataset.service.js
@@ -184,8 +184,22 @@ class DatasetService {
         return query;
     }
 
+    static async getAllDatasetUserIds() {
+        logger.debug(`[DatasetService]: Getting the user ids of all datasets`);
+        const datasets = await Dataset.find({}, 'userId').lean();
+        const userIds = datasets.map(d => d.userId);
+        return userIds.filter((item, idx) => userIds.indexOf(item) === idx && item !== 'legacy');
+    }
+
+    static processSortParam(sort) {
+        let processedStr = sort;
+        if (sort.includes('user.role')) processedStr = processedStr.replace(/user.role/g, 'userRole');
+        if (sort.includes('user.name')) processedStr = processedStr.replace(/user.name/g, 'userName');
+        return processedStr;
+    }
+
     static getFilteredSort(sort) {
-        const sortParams = sort.split(',');
+        const sortParams = DatasetService.processSortParam(sort).split(',');
         const filteredSort = {};
         const datasetAttributes = Object.keys(Dataset.schema.obj);
         sortParams.forEach((param) => {

--- a/app/src/services/dataset.service.js
+++ b/app/src/services/dataset.service.js
@@ -192,10 +192,7 @@ class DatasetService {
     }
 
     static processSortParam(sort) {
-        let processedStr = sort;
-        if (sort.includes('user.role')) processedStr = processedStr.replace(/user.role/g, 'userRole');
-        if (sort.includes('user.name')) processedStr = processedStr.replace(/user.name/g, 'userName');
-        return processedStr;
+        return sort.replace(/user.role/g, 'userRole').replace(/user.name/g, 'userName');
     }
 
     static getFilteredSort(sort) {

--- a/app/src/services/dataset.service.js
+++ b/app/src/services/dataset.service.js
@@ -187,8 +187,8 @@ class DatasetService {
     static async getAllDatasetUserIds() {
         logger.debug(`[DatasetService]: Getting the user ids of all datasets`);
         const datasets = await Dataset.find({}, 'userId').lean();
-        const userIds = datasets.map(d => d.userId);
-        return userIds.filter((item, idx) => userIds.indexOf(item) === idx && item !== 'legacy');
+        const userIds = datasets.map(dataset => dataset.userId);
+        return userIds.filter((item, idx) => userIds.indexOf(item) === idx);
     }
 
     static processSortParam(sort) {

--- a/app/src/services/dataset.service.js
+++ b/app/src/services/dataset.service.js
@@ -192,7 +192,7 @@ class DatasetService {
     }
 
     static processSortParam(sort) {
-        return sort.replace(/user.role/g, 'userRole').replace(/user.name/g, 'userName');
+        return sort.replace(/user.role/g, 'userRole,_id').replace(/user.name/g, 'userName,_id');
     }
 
     static getFilteredSort(sort) {

--- a/app/src/services/relationships.service.js
+++ b/app/src/services/relationships.service.js
@@ -320,7 +320,7 @@ class RelationshipsService {
             method: 'POST',
             json: true,
             version: false,
-            body: { ids: ids.sort() }
+            body: { ids }
         });
 
         return body.data;

--- a/app/src/services/relationships.service.js
+++ b/app/src/services/relationships.service.js
@@ -59,6 +59,10 @@ class RelationshipsService {
                     logger.debug('test uriQuery => ', `${uri}/${include}/find-by-ids?${uriQuery}`);
                     logger.debug('test payload length => ', ((payload || {}).ids || []).length);
 
+                    if (payload.ids) {
+                        payload.ids = payload.ids.filter(id => id && id !== 'legacy').sort();
+                    }
+
                     obj[include] = await ctRegisterMicroservice.requestToMicroservice({
                         uri: `${uri}/${include}/find-by-ids${uriQuery}`,
                         method: 'POST',
@@ -307,6 +311,19 @@ class RelationshipsService {
         } catch (e) {
             throw new Error(`Error searching by label synonyms: ${e}`);
         }
+    }
+
+    static async getUsersInfoByIds(ids) {
+        logger.debug('Fetching all users\' information');
+        const body = await ctRegisterMicroservice.requestToMicroservice({
+            uri: `/auth/user/find-by-ids`,
+            method: 'POST',
+            json: true,
+            version: false,
+            body: { ids: ids.sort() }
+        });
+
+        return body.data;
     }
 
 }

--- a/app/src/services/relationships.service.js
+++ b/app/src/services/relationships.service.js
@@ -58,11 +58,6 @@ class RelationshipsService {
                 try {
                     logger.debug('test uriQuery => ', `${uri}/${include}/find-by-ids?${uriQuery}`);
                     logger.debug('test payload length => ', ((payload || {}).ids || []).length);
-
-                    if (payload.ids) {
-                        payload.ids = payload.ids.filter(id => id && id !== 'legacy').sort();
-                    }
-
                     obj[include] = await ctRegisterMicroservice.requestToMicroservice({
                         uri: `${uri}/${include}/find-by-ids${uriQuery}`,
                         method: 'POST',

--- a/app/test/e2e/dataset-clone.spec.js
+++ b/app/test/e2e/dataset-clone.spec.js
@@ -18,8 +18,6 @@ describe('Dataset clone tests', () => {
         if (process.env.NODE_ENV !== 'test') {
             throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
         }
-
-        nock.cleanAll();
     });
 
     beforeEach(async () => {

--- a/app/test/e2e/dataset-create.spec.js
+++ b/app/test/e2e/dataset-create.spec.js
@@ -21,8 +21,6 @@ describe('Dataset create tests', () => {
         }
 
         await Dataset.deleteMany({}).exec();
-
-        nock.cleanAll();
     });
 
     /* Create a Carto Dataset */

--- a/app/test/e2e/dataset-find-by-ids.spec.js
+++ b/app/test/e2e/dataset-find-by-ids.spec.js
@@ -20,8 +20,6 @@ describe('Find by ids datasets', () => {
             throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
         }
 
-        nock.cleanAll();
-
         await Dataset.deleteMany({}).exec();
 
         cartoFakeDataset = await new Dataset(createDataset('cartodb')).save();

--- a/app/test/e2e/dataset-flush.spec.js
+++ b/app/test/e2e/dataset-flush.spec.js
@@ -16,8 +16,6 @@ describe('Upload raw data', () => {
         if (process.env.NODE_ENV !== 'test') {
             throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
         }
-
-        nock.cleanAll();
     });
 
     it('Return 401 error if no user provided', async () => {

--- a/app/test/e2e/dataset-get-includes.spec.js
+++ b/app/test/e2e/dataset-get-includes.spec.js
@@ -31,8 +31,6 @@ describe('Get datasets with includes tests', () => {
             throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
         }
 
-        nock.cleanAll();
-
         await Dataset.deleteMany({}).exec();
     });
 

--- a/app/test/e2e/dataset-get-includes.spec.js
+++ b/app/test/e2e/dataset-get-includes.spec.js
@@ -265,7 +265,6 @@ describe('Get datasets with includes tests', () => {
         const fakeDatasetThree = await new Dataset(createDataset('cartodb')).save();
 
         createMockUser([{
-            id: fakeDatasetOne.userId,
             _id: fakeDatasetOne.userId,
             provider: 'local',
             name: 'test user',
@@ -282,7 +281,6 @@ describe('Get datasets with includes tests', () => {
                 ]
             }
         }, {
-            id: fakeDatasetTwo.userId,
             _id: fakeDatasetTwo.userId,
             role: 'MANAGER',
             provider: 'local',
@@ -298,7 +296,6 @@ describe('Get datasets with includes tests', () => {
                 ]
             }
         }, {
-            id: fakeDatasetThree.userId,
             _id: fakeDatasetThree.userId,
             role: 'MANAGER',
             provider: 'local',

--- a/app/test/e2e/dataset-get-includes.spec.js
+++ b/app/test/e2e/dataset-get-includes.spec.js
@@ -5,6 +5,7 @@ const Dataset = require('models/dataset.model');
 const fs = require('fs');
 const path = require('path');
 const { createDataset, deserializeDataset } = require('./utils');
+const { createMockUser } = require('./mocks');
 
 const metadataGetWithSearchForHuman = require('./dataset-get-includes-responses/metadata-get-search-human');
 const widgetsFindById = require('./dataset-get-includes-responses/widget-find-by-ids');
@@ -265,54 +266,51 @@ describe('Get datasets with includes tests', () => {
         const fakeDatasetTwo = await new Dataset(createDataset('cartodb')).save();
         const fakeDatasetThree = await new Dataset(createDataset('cartodb')).save();
 
-        nock(process.env.CT_URL)
-            .post(`/auth/user/find-by-ids`, {
-                ids: [fakeDatasetOne.userId, fakeDatasetTwo.userId, fakeDatasetThree.userId]
-            })
-            .reply(200, {
-                data: [{
-                    _id: fakeDatasetOne.userId,
-                    provider: 'local',
-                    name: 'test user',
-                    email: 'user-one@control-tower.org',
-                    role: 'USER',
-                    extraUserData: {
-                        apps: [
-                            'rw',
-                            'gfw',
-                            'gfw-climate',
-                            'prep',
-                            'aqueduct',
-                            'forest-atlas'
-                        ]
-                    }
-                }, {
-                    _id: fakeDatasetTwo.userId,
-                    role: 'MANAGER',
-                    provider: 'local',
-                    email: 'user-two@control-tower.org',
-                    extraUserData: {
-                        apps: [
-                            'rw',
-                            'gfw',
-                            'gfw-climate',
-                            'prep',
-                            'aqueduct',
-                            'forest-atlas'
-                        ]
-                    }
-                }, {
-                    _id: fakeDatasetThree.userId,
-                    role: 'MANAGER',
-                    provider: 'local',
-                    name: 'user three',
-                    extraUserData: {
-                        apps: [
-                            'rw'
-                        ]
-                    }
-                }]
-            });
+        createMockUser([{
+            id: fakeDatasetOne.userId,
+            _id: fakeDatasetOne.userId,
+            provider: 'local',
+            name: 'test user',
+            email: 'user-one@control-tower.org',
+            role: 'USER',
+            extraUserData: {
+                apps: [
+                    'rw',
+                    'gfw',
+                    'gfw-climate',
+                    'prep',
+                    'aqueduct',
+                    'forest-atlas'
+                ]
+            }
+        }, {
+            id: fakeDatasetTwo.userId,
+            _id: fakeDatasetTwo.userId,
+            role: 'MANAGER',
+            provider: 'local',
+            email: 'user-two@control-tower.org',
+            extraUserData: {
+                apps: [
+                    'rw',
+                    'gfw',
+                    'gfw-climate',
+                    'prep',
+                    'aqueduct',
+                    'forest-atlas'
+                ]
+            }
+        }, {
+            id: fakeDatasetThree.userId,
+            _id: fakeDatasetThree.userId,
+            role: 'MANAGER',
+            provider: 'local',
+            name: 'user three',
+            extraUserData: {
+                apps: [
+                    'rw'
+                ]
+            }
+        }]);
 
         const response = await requester
             .get(`/api/v1/dataset`)

--- a/app/test/e2e/dataset-get-sort-user-fields.spec.js
+++ b/app/test/e2e/dataset-get-sort-user-fields.spec.js
@@ -22,10 +22,8 @@ const mockUsersForSort = (users) => {
     const allUsers = users.map(u => ({ ...u, _id: u.id }));
 
     // Mock all users request (for sorting by user role)
-    createMockUser(allUsers, true);
-
-    // Mock each user request (for includes=user)
-    allUsers.map(user => createMockUser([user]));
+    createMockUser(allUsers);
+    createMockUser(allUsers);
 };
 
 const mockFourDatasetsForSorting = async () => {
@@ -79,7 +77,6 @@ describe('GET datasets sorted by user fields', () => {
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('array').and.length(4);
         response.body.data.map(dataset => dataset.attributes.user.role).should.be.deep.equal(['ADMIN', 'MANAGER', 'SUPERADMIN', 'USER']);
-        nock.cleanAll();
     });
 
     it('Getting datasets sorted by user.role DESC should return a list of datasets ordered by the role of the user who created the dataset (happy case)', async () => {
@@ -92,7 +89,6 @@ describe('GET datasets sorted by user fields', () => {
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('array').and.length(4);
         response.body.data.map(dataset => dataset.attributes.user.role).should.be.deep.equal(['USER', 'SUPERADMIN', 'MANAGER', 'ADMIN']);
-        nock.cleanAll();
     });
 
     it('Getting datasets sorted by user.name ASC should return a list of datasets ordered by the name of the user who created the dataset (happy case)', async () => {
@@ -105,7 +101,6 @@ describe('GET datasets sorted by user fields', () => {
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('array').and.length(4);
         response.body.data.map(dataset => dataset.attributes.user.name).should.be.deep.equal(['test admin', 'test manager', 'test super admin', 'test user']);
-        nock.cleanAll();
     });
 
     it('Getting datasets sorted by user.name DESC should return a list of datasets ordered by the name of the user who created the dataset (happy case)', async () => {
@@ -118,7 +113,6 @@ describe('GET datasets sorted by user fields', () => {
         response.status.should.equal(200);
         response.body.should.have.property('data').and.be.an('array').and.length(4);
         response.body.data.map(dataset => dataset.attributes.user.name).should.be.deep.equal(['test user', 'test super admin', 'test manager', 'test admin']);
-        nock.cleanAll();
     });
 
     it('Sorting datasets by user role ASC puts datasets without valid users in the beginning of the list', async () => {
@@ -142,7 +136,6 @@ describe('GET datasets sorted by user fields', () => {
 
         const returnedNoUserDataset = response.body.data.find(dataset => dataset.id === noUserDataset._id);
         response.body.data.indexOf(returnedNoUserDataset).should.be.equal(0);
-        nock.cleanAll();
     });
 
     it('Sorting datasets by user role DESC puts datasets without valid users in the end of the list', async () => {
@@ -166,7 +159,6 @@ describe('GET datasets sorted by user fields', () => {
 
         const returnedNoUserDataset = response.body.data.find(dataset => dataset.id === noUserDataset._id);
         response.body.data.indexOf(returnedNoUserDataset).should.be.equal(4);
-        nock.cleanAll();
     });
 
     afterEach(async () => {

--- a/app/test/e2e/dataset-get-sort-user-fields.spec.js
+++ b/app/test/e2e/dataset-get-sort-user-fields.spec.js
@@ -1,0 +1,179 @@
+const nock = require('nock');
+const Dataset = require('models/dataset.model');
+const chai = require('chai');
+const { getTestServer } = require('./test-server');
+const { createDataset } = require('./utils');
+const { createMockUser } = require('./mocks');
+const {
+    USERS: {
+        USER, MANAGER, ADMIN, SUPERADMIN
+    }
+} = require('./test.constants');
+
+chai.should();
+
+nock.disableNetConnect();
+nock.enableNetConnect(process.env.HOST_IP);
+
+let requester;
+
+const mockUsersForSort = (users) => {
+    // Add _id property to provided users (some stuff uses _id, some uses id :shrug:)
+    const allUsers = users.map(u => ({ ...u, _id: u.id }));
+
+    // Mock all users request (for sorting by user role)
+    createMockUser(allUsers, true);
+
+    // Mock each user request (for includes=user)
+    allUsers.map(user => createMockUser([user]));
+};
+
+const mockFourDatasetsForSorting = async () => {
+    await new Dataset(createDataset('cartodb', { userId: USER.id })).save();
+    await new Dataset(createDataset('cartodb', { userId: MANAGER.id })).save();
+    await new Dataset(createDataset('cartodb', { userId: ADMIN.id })).save();
+    await new Dataset(createDataset('cartodb', { userId: SUPERADMIN.id })).save();
+
+    mockUsersForSort([
+        USER, MANAGER, ADMIN, SUPERADMIN
+    ]);
+};
+
+describe('GET datasets sorted by user fields', () => {
+    before(async () => {
+        if (process.env.NODE_ENV !== 'test') {
+            throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
+        }
+
+        requester = await getTestServer();
+    });
+
+    it('Getting datasets sorted by user.role ASC without authentication should return 403 Forbidden', async () => {
+        const response = await requester.get('/api/v1/dataset').query({ sort: 'user.role' });
+        response.status.should.equal(403);
+        response.body.should.have.property('errors').and.be.an('array');
+        response.body.errors[0].should.have.property('detail').and.be.equal('Sorting by user name or role not authorized.');
+    });
+
+    it('Getting datasets sorted by user.role ASC with user with role USER should return 403 Forbidden', async () => {
+        const response = await requester.get('/api/v1/dataset').query({ sort: 'user.role', loggedUser: JSON.stringify(USER) });
+        response.status.should.equal(403);
+        response.body.should.have.property('errors').and.be.an('array');
+        response.body.errors[0].should.have.property('detail').and.be.equal('Sorting by user name or role not authorized.');
+    });
+
+    it('Getting datasets sorted by user.role ASC with user with role MANAGER should return 403 Forbidden', async () => {
+        const response = await requester.get('/api/v1/dataset').query({ sort: 'user.role', loggedUser: JSON.stringify(MANAGER) });
+        response.status.should.equal(403);
+        response.body.should.have.property('errors').and.be.an('array');
+        response.body.errors[0].should.have.property('detail').and.be.equal('Sorting by user name or role not authorized.');
+    });
+
+    it('Getting datasets sorted by user.role ASC should return a list of datasets ordered by the role of the user who created the dataset (happy case)', async () => {
+        await mockFourDatasetsForSorting();
+        const response = await requester.get('/api/v1/dataset').query({
+            includes: 'user',
+            sort: 'user.role',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(4);
+        response.body.data.map(dataset => dataset.attributes.user.role).should.be.deep.equal(['ADMIN', 'MANAGER', 'SUPERADMIN', 'USER']);
+        nock.cleanAll();
+    });
+
+    it('Getting datasets sorted by user.role DESC should return a list of datasets ordered by the role of the user who created the dataset (happy case)', async () => {
+        await mockFourDatasetsForSorting();
+        const response = await requester.get('/api/v1/dataset').query({
+            includes: 'user',
+            sort: '-user.role',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(4);
+        response.body.data.map(dataset => dataset.attributes.user.role).should.be.deep.equal(['USER', 'SUPERADMIN', 'MANAGER', 'ADMIN']);
+        nock.cleanAll();
+    });
+
+    it('Getting datasets sorted by user.name ASC should return a list of datasets ordered by the name of the user who created the dataset (happy case)', async () => {
+        await mockFourDatasetsForSorting();
+        const response = await requester.get('/api/v1/dataset').query({
+            includes: 'user',
+            sort: 'user.name',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(4);
+        response.body.data.map(dataset => dataset.attributes.user.name).should.be.deep.equal(['test admin', 'test manager', 'test super admin', 'test user']);
+        nock.cleanAll();
+    });
+
+    it('Getting datasets sorted by user.name DESC should return a list of datasets ordered by the name of the user who created the dataset (happy case)', async () => {
+        await mockFourDatasetsForSorting();
+        const response = await requester.get('/api/v1/dataset').query({
+            includes: 'user',
+            sort: '-user.name',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(4);
+        response.body.data.map(dataset => dataset.attributes.user.name).should.be.deep.equal(['test user', 'test super admin', 'test manager', 'test admin']);
+        nock.cleanAll();
+    });
+
+    it('Sorting datasets by user role ASC puts datasets without valid users in the beginning of the list', async () => {
+        await new Dataset(createDataset('cartodb', { userId: USER.id })).save();
+        await new Dataset(createDataset('cartodb', { userId: MANAGER.id })).save();
+        await new Dataset(createDataset('cartodb', { userId: ADMIN.id })).save();
+        await new Dataset(createDataset('cartodb', { userId: SUPERADMIN.id })).save();
+        const noUserDataset = await new Dataset(createDataset('cartodb', { userId: 'legacy' })).save();
+
+        mockUsersForSort([
+            USER, MANAGER, ADMIN, SUPERADMIN
+        ]);
+
+        const response = await requester.get('/api/v1/dataset').query({
+            includes: 'user',
+            sort: 'user.role',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(5);
+
+        const returnedNoUserDataset = response.body.data.find(dataset => dataset.id === noUserDataset._id);
+        response.body.data.indexOf(returnedNoUserDataset).should.be.equal(0);
+        nock.cleanAll();
+    });
+
+    it('Sorting datasets by user role DESC puts datasets without valid users in the end of the list', async () => {
+        await new Dataset(createDataset('cartodb', { userId: USER.id })).save();
+        await new Dataset(createDataset('cartodb', { userId: MANAGER.id })).save();
+        await new Dataset(createDataset('cartodb', { userId: ADMIN.id })).save();
+        await new Dataset(createDataset('cartodb', { userId: SUPERADMIN.id })).save();
+        const noUserDataset = await new Dataset(createDataset('cartodb', { userId: 'legacy' })).save();
+
+        mockUsersForSort([
+            USER, MANAGER, ADMIN, SUPERADMIN
+        ]);
+
+        const response = await requester.get('/api/v1/dataset').query({
+            includes: 'user',
+            sort: '-user.role',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(5);
+
+        const returnedNoUserDataset = response.body.data.find(dataset => dataset.id === noUserDataset._id);
+        response.body.data.indexOf(returnedNoUserDataset).should.be.equal(4);
+        nock.cleanAll();
+    });
+
+    afterEach(async () => {
+        await Dataset.deleteMany({}).exec();
+
+        if (!nock.isDone()) {
+            throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);
+        }
+    });
+});

--- a/app/test/e2e/dataset-get-sort-user-fields.spec.js
+++ b/app/test/e2e/dataset-get-sort-user-fields.spec.js
@@ -123,7 +123,7 @@ describe('GET datasets sorted by user fields', () => {
         const noUserDataset = await new Dataset(createDataset('cartodb', { userId: 'legacy' })).save();
 
         mockUsersForSort([
-            USER, MANAGER, ADMIN, SUPERADMIN
+            USER, MANAGER, ADMIN, SUPERADMIN, { id: 'legacy' }
         ]);
 
         const response = await requester.get('/api/v1/dataset').query({
@@ -146,7 +146,7 @@ describe('GET datasets sorted by user fields', () => {
         const noUserDataset = await new Dataset(createDataset('cartodb', { userId: 'legacy' })).save();
 
         mockUsersForSort([
-            USER, MANAGER, ADMIN, SUPERADMIN
+            USER, MANAGER, ADMIN, SUPERADMIN, { id: 'legacy' }
         ]);
 
         const response = await requester.get('/api/v1/dataset').query({

--- a/app/test/e2e/dataset-get-sort-user-fields.spec.js
+++ b/app/test/e2e/dataset-get-sort-user-fields.spec.js
@@ -164,6 +164,25 @@ describe('GET datasets sorted by user fields', () => {
         response.body.data.indexOf(returnedNoUserDataset).should.be.equal(4);
     });
 
+    it('Sorting datasets by user.name is case insensitive and returns a list of datasets ordered by the name of the user who created the dataset', async () => {
+        const firstUser = { ...USER, name: 'Anthony' };
+        const secondUser = { ...MANAGER, name: 'bernard' };
+        const thirdUser = { ...ADMIN, name: 'Carlos' };
+        await new Dataset(createDataset('cartodb', { userId: firstUser.id })).save();
+        await new Dataset(createDataset('cartodb', { userId: secondUser.id })).save();
+        await new Dataset(createDataset('cartodb', { userId: thirdUser.id })).save();
+        mockUsersForSort([firstUser, secondUser, thirdUser]);
+
+        const response = await requester.get('/api/v1/dataset').query({
+            includes: 'user',
+            sort: 'user.name',
+            loggedUser: JSON.stringify(ADMIN),
+        });
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('array').and.length(3);
+        response.body.data.map(dataset => dataset.attributes.user.name).should.be.deep.equal(['Anthony', 'bernard', 'Carlos']);
+    });
+
     afterEach(async () => {
         await Dataset.deleteMany({}).exec();
 

--- a/app/test/e2e/dataset-get-sort-user-fields.spec.js
+++ b/app/test/e2e/dataset-get-sort-user-fields.spec.js
@@ -1,6 +1,7 @@
 const nock = require('nock');
 const Dataset = require('models/dataset.model');
 const chai = require('chai');
+const mongoose = require('mongoose');
 const { getTestServer } = require('./test-server');
 const { createDataset } = require('./utils');
 const { createMockUser } = require('./mocks');
@@ -26,14 +27,16 @@ const mockUsersForSort = (users) => {
     createMockUser(allUsers);
 };
 
-const mockFourDatasetsForSorting = async () => {
+const mockDatasetsForSorting = async () => {
+    const id = mongoose.Types.ObjectId();
     await new Dataset(createDataset('cartodb', { userId: USER.id })).save();
     await new Dataset(createDataset('cartodb', { userId: MANAGER.id })).save();
     await new Dataset(createDataset('cartodb', { userId: ADMIN.id })).save();
     await new Dataset(createDataset('cartodb', { userId: SUPERADMIN.id })).save();
+    await new Dataset(createDataset('cartodb', { userId: id })).save();
 
     mockUsersForSort([
-        USER, MANAGER, ADMIN, SUPERADMIN
+        USER, MANAGER, ADMIN, SUPERADMIN, { id }
     ]);
 };
 
@@ -68,51 +71,51 @@ describe('GET datasets sorted by user fields', () => {
     });
 
     it('Getting datasets sorted by user.role ASC should return a list of datasets ordered by the role of the user who created the dataset (happy case)', async () => {
-        await mockFourDatasetsForSorting();
+        await mockDatasetsForSorting();
         const response = await requester.get('/api/v1/dataset').query({
             includes: 'user',
             sort: 'user.role',
             loggedUser: JSON.stringify(ADMIN),
         });
         response.status.should.equal(200);
-        response.body.should.have.property('data').and.be.an('array').and.length(4);
-        response.body.data.map(dataset => dataset.attributes.user.role).should.be.deep.equal(['ADMIN', 'MANAGER', 'SUPERADMIN', 'USER']);
+        response.body.should.have.property('data').and.be.an('array').and.length(5);
+        response.body.data.map(dataset => dataset.attributes.user.role).should.be.deep.equal([undefined, 'ADMIN', 'MANAGER', 'SUPERADMIN', 'USER']);
     });
 
     it('Getting datasets sorted by user.role DESC should return a list of datasets ordered by the role of the user who created the dataset (happy case)', async () => {
-        await mockFourDatasetsForSorting();
+        await mockDatasetsForSorting();
         const response = await requester.get('/api/v1/dataset').query({
             includes: 'user',
             sort: '-user.role',
             loggedUser: JSON.stringify(ADMIN),
         });
         response.status.should.equal(200);
-        response.body.should.have.property('data').and.be.an('array').and.length(4);
-        response.body.data.map(dataset => dataset.attributes.user.role).should.be.deep.equal(['USER', 'SUPERADMIN', 'MANAGER', 'ADMIN']);
+        response.body.should.have.property('data').and.be.an('array').and.length(5);
+        response.body.data.map(dataset => dataset.attributes.user.role).should.be.deep.equal(['USER', 'SUPERADMIN', 'MANAGER', 'ADMIN', undefined]);
     });
 
     it('Getting datasets sorted by user.name ASC should return a list of datasets ordered by the name of the user who created the dataset (happy case)', async () => {
-        await mockFourDatasetsForSorting();
+        await mockDatasetsForSorting();
         const response = await requester.get('/api/v1/dataset').query({
             includes: 'user',
             sort: 'user.name',
             loggedUser: JSON.stringify(ADMIN),
         });
         response.status.should.equal(200);
-        response.body.should.have.property('data').and.be.an('array').and.length(4);
-        response.body.data.map(dataset => dataset.attributes.user.name).should.be.deep.equal(['test admin', 'test manager', 'test super admin', 'test user']);
+        response.body.should.have.property('data').and.be.an('array').and.length(5);
+        response.body.data.map(dataset => dataset.attributes.user.name).should.be.deep.equal([undefined, 'test admin', 'test manager', 'test super admin', 'test user']);
     });
 
     it('Getting datasets sorted by user.name DESC should return a list of datasets ordered by the name of the user who created the dataset (happy case)', async () => {
-        await mockFourDatasetsForSorting();
+        await mockDatasetsForSorting();
         const response = await requester.get('/api/v1/dataset').query({
             includes: 'user',
             sort: '-user.name',
             loggedUser: JSON.stringify(ADMIN),
         });
         response.status.should.equal(200);
-        response.body.should.have.property('data').and.be.an('array').and.length(4);
-        response.body.data.map(dataset => dataset.attributes.user.name).should.be.deep.equal(['test user', 'test super admin', 'test manager', 'test admin']);
+        response.body.should.have.property('data').and.be.an('array').and.length(5);
+        response.body.data.map(dataset => dataset.attributes.user.name).should.be.deep.equal(['test user', 'test super admin', 'test manager', 'test admin', undefined]);
     });
 
     it('Sorting datasets by user role ASC puts datasets without valid users in the beginning of the list', async () => {

--- a/app/test/e2e/dataset-get.spec.js
+++ b/app/test/e2e/dataset-get.spec.js
@@ -18,8 +18,6 @@ describe('Get datasets tests', () => {
         if (process.env.NODE_ENV !== 'test') {
             throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
         }
-
-        nock.cleanAll();
     });
 
     /* Get All Datasets */

--- a/app/test/e2e/dataset-get.spec.js
+++ b/app/test/e2e/dataset-get.spec.js
@@ -234,6 +234,11 @@ describe('Get datasets tests', () => {
         datasetIds.should.not.contain(ds4._id);
     });
 
+
+    /**
+     * We'll want to limit the maximum page size in the future
+     * However, as this will cause a production BC break, we can't enforce it just now
+     */
     // it('Getting datasets with page size over 100 should return 400 Bad Request', async () => {
     //     const list = await requester.get('/api/v1/dataset?page[size]=101');
     //     list.status.should.equal(400);

--- a/app/test/e2e/dataset-get.spec.js
+++ b/app/test/e2e/dataset-get.spec.js
@@ -234,11 +234,11 @@ describe('Get datasets tests', () => {
         datasetIds.should.not.contain(ds4._id);
     });
 
-    it('Getting datasets with page size over 100 should return 400 Bad Request', async () => {
-        const list = await requester.get('/api/v1/dataset?page[size]=101');
-        list.status.should.equal(400);
-        list.body.errors[0].should.have.property('detail').and.equal('Invalid page size');
-    });
+    // it('Getting datasets with page size over 100 should return 400 Bad Request', async () => {
+    //     const list = await requester.get('/api/v1/dataset?page[size]=101');
+    //     list.status.should.equal(400);
+    //     list.body.errors[0].should.have.property('detail').and.equal('Invalid page size');
+    // });
 
     afterEach(async () => {
         if (!nock.isDone()) {

--- a/app/test/e2e/dataset-get.spec.js
+++ b/app/test/e2e/dataset-get.spec.js
@@ -234,6 +234,12 @@ describe('Get datasets tests', () => {
         datasetIds.should.not.contain(ds4._id);
     });
 
+    it('Getting datasets with page size over 100 should return 400 Bad Request', async () => {
+        const list = await requester.get('/api/v1/dataset?page[size]=101');
+        list.status.should.equal(400);
+        list.body.errors[0].should.have.property('detail').and.equal('Invalid page size');
+    });
+
     afterEach(async () => {
         if (!nock.isDone()) {
             throw new Error(`Not all nock interceptors were used: ${nock.pendingMocks()}`);

--- a/app/test/e2e/dataset-recover.spec.js
+++ b/app/test/e2e/dataset-recover.spec.js
@@ -18,8 +18,6 @@ describe('Upload raw data', () => {
             throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
         }
 
-        nock.cleanAll();
-
         await Dataset.deleteMany({}).exec();
 
         jsonFakeDataset = await new Dataset(createDataset('json')).save();

--- a/app/test/e2e/dataset-search.spec.js
+++ b/app/test/e2e/dataset-search.spec.js
@@ -21,8 +21,6 @@ describe('Search datasets tests', () => {
             throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
         }
 
-        nock.cleanAll();
-
         await Dataset.deleteMany({}).exec();
 
         cartoFakeDataset = await new Dataset(createDataset('cartodb')).save();

--- a/app/test/e2e/dataset-sort.spec.js
+++ b/app/test/e2e/dataset-sort.spec.js
@@ -21,8 +21,6 @@ describe('Sort datasets tests', () => {
             throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
         }
 
-        nock.cleanAll();
-
         await Dataset.deleteMany({}).exec();
 
         cartoFakeDataset = await new Dataset(createDataset('cartodb')).save();

--- a/app/test/e2e/dataset-upload.spec.js
+++ b/app/test/e2e/dataset-upload.spec.js
@@ -18,8 +18,6 @@ describe('Upload raw data', () => {
             throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
         }
 
-        nock.cleanAll();
-
         await Dataset.deleteMany({}).exec();
     });
 

--- a/app/test/e2e/dataset-verification.spec.js
+++ b/app/test/e2e/dataset-verification.spec.js
@@ -21,8 +21,6 @@ describe('Upload raw data', () => {
             throw Error(`Running the test suite with NODE_ENV ${process.env.NODE_ENV} may result in permanent data loss. Please use NODE_ENV=test.`);
         }
 
-        nock.cleanAll();
-
         await Dataset.deleteMany({}).exec();
 
         jsonFakeDataset = await new Dataset(createDataset('json')).save();

--- a/app/test/e2e/mocks.js
+++ b/app/test/e2e/mocks.js
@@ -1,11 +1,14 @@
 const nock = require('nock');
+const intersection = require('lodash/intersection');
 
-const createMockUser = (mockUser, persist = false) => {
-    let scope = nock(process.env.CT_URL);
-    if (persist) scope = scope.persist();
-    scope.post(/.*auth\/user\/find-by-ids.*/, JSON.stringify({ ids: mockUser.map(e => e.id).sort() }))
+const createMockUser = (users) => {
+    nock(process.env.CT_URL)
+        .post(
+            '/auth/user/find-by-ids',
+            body => intersection(body.ids, users.map(e => e.id)).length === body.ids.length
+        )
         .query(() => true)
-        .reply(200, { data: mockUser });
+        .reply(200, { data: users });
 };
 
 module.exports = { createMockUser };

--- a/app/test/e2e/mocks.js
+++ b/app/test/e2e/mocks.js
@@ -5,7 +5,7 @@ const createMockUser = (users) => {
     nock(process.env.CT_URL)
         .post(
             '/auth/user/find-by-ids',
-            body => intersection(body.ids, users.map(e => e.id)).length === body.ids.length
+            body => intersection(body.ids, users.map(e => e._id.toString())).length >= body.ids.length
         )
         .query(() => true)
         .reply(200, { data: users });

--- a/app/test/e2e/mocks.js
+++ b/app/test/e2e/mocks.js
@@ -1,0 +1,11 @@
+const nock = require('nock');
+
+const createMockUser = (mockUser, persist = false) => {
+    let scope = nock(process.env.CT_URL);
+    if (persist) scope = scope.persist();
+    scope.post(/.*auth\/user\/find-by-ids.*/, JSON.stringify({ ids: mockUser.map(e => e.id).sort() }))
+        .query(() => true)
+        .reply(200, { data: mockUser });
+};
+
+module.exports = { createMockUser };

--- a/app/test/e2e/mocks.js
+++ b/app/test/e2e/mocks.js
@@ -5,7 +5,7 @@ const createMockUser = (users) => {
     nock(process.env.CT_URL)
         .post(
             '/auth/user/find-by-ids',
-            body => intersection(body.ids, users.map(e => e._id.toString())).length >= body.ids.length
+            body => intersection(body.ids, users.map(e => e._id.toString())).length === body.ids.length
         )
         .query(() => true)
         .reply(200, { data: users });

--- a/app/test/e2e/test.constants.js
+++ b/app/test/e2e/test.constants.js
@@ -2,6 +2,7 @@
 const USERS = {
     USER: {
         id: '1a10d7c6e0a37126611fd7a5',
+        name: 'test user',
         role: 'USER',
         provider: 'local',
         email: 'user@control-tower.org',
@@ -19,6 +20,7 @@ const USERS = {
     },
     MANAGER: {
         id: '1a10d7c6e0a37126611fd7a6',
+        name: 'test manager',
         role: 'MANAGER',
         provider: 'local',
         email: 'user@control-tower.org',
@@ -36,10 +38,28 @@ const USERS = {
     },
     ADMIN: {
         id: '1a10d7c6e0a37126611fd7a7',
+        name: 'test admin',
         role: 'ADMIN',
         provider: 'local',
         email: 'user@control-tower.org',
-        name: 'John Admin',
+        extraUserData: {
+            apps: [
+                'rw',
+                'gfw',
+                'gfw-climate',
+                'prep',
+                'aqueduct',
+                'forest-atlas',
+                'data4sdgs'
+            ]
+        }
+    },
+    SUPERADMIN: {
+        id: '1a10d7c6e0a37126601fd7a6',
+        role: 'SUPERADMIN',
+        provider: 'local',
+        email: 'user@control-tower.org',
+        name: 'test super admin',
         extraUserData: {
             apps: [
                 'rw',

--- a/app/test/e2e/test.constants.js
+++ b/app/test/e2e/test.constants.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-len */
 const USERS = {
     USER: {
+        _id: '1a10d7c6e0a37126611fd7a5',
         id: '1a10d7c6e0a37126611fd7a5',
         name: 'test user',
         role: 'USER',
@@ -19,6 +20,7 @@ const USERS = {
         }
     },
     MANAGER: {
+        _id: '1a10d7c6e0a37126611fd7a6',
         id: '1a10d7c6e0a37126611fd7a6',
         name: 'test manager',
         role: 'MANAGER',
@@ -37,6 +39,7 @@ const USERS = {
         }
     },
     ADMIN: {
+        _id: '1a10d7c6e0a37126611fd7a7',
         id: '1a10d7c6e0a37126611fd7a7',
         name: 'test admin',
         role: 'ADMIN',
@@ -55,6 +58,7 @@ const USERS = {
         }
     },
     SUPERADMIN: {
+        _id: '1a10d7c6e0a37126601fd7a6',
         id: '1a10d7c6e0a37126601fd7a6',
         role: 'SUPERADMIN',
         provider: 'local',

--- a/app/test/e2e/test.constants.js
+++ b/app/test/e2e/test.constants.js
@@ -1,7 +1,6 @@
 /* eslint-disable max-len */
 const USERS = {
     USER: {
-        _id: '1a10d7c6e0a37126611fd7a5',
         id: '1a10d7c6e0a37126611fd7a5',
         name: 'test user',
         role: 'USER',
@@ -20,7 +19,6 @@ const USERS = {
         }
     },
     MANAGER: {
-        _id: '1a10d7c6e0a37126611fd7a6',
         id: '1a10d7c6e0a37126611fd7a6',
         name: 'test manager',
         role: 'MANAGER',
@@ -39,7 +37,6 @@ const USERS = {
         }
     },
     ADMIN: {
-        _id: '1a10d7c6e0a37126611fd7a7',
         id: '1a10d7c6e0a37126611fd7a7',
         name: 'test admin',
         role: 'ADMIN',
@@ -58,7 +55,6 @@ const USERS = {
         }
     },
     SUPERADMIN: {
-        _id: '1a10d7c6e0a37126601fd7a6',
         id: '1a10d7c6e0a37126601fd7a6',
         role: 'SUPERADMIN',
         provider: 'local',

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -10,6 +10,7 @@ services:
       CT_URL: http://mymachine:9000
       API_VERSION: v1
       STAMPERY_TOKEN: token
+      CT_REGISTER_MODE: auto
       MONGO_PORT_27017_TCP_ADDR: mongo
       S3_ACCESS_KEY_ID: foo
       S3_SECRET_ACCESS_KEY: bar


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/169174283

## What does this PR add?

This PR adds the possibility of sorting datasets according to the role or name of the user to whom the dataset belongs.

It should be noted that, in order to accomplish this, **all datasets are updated with the current role and name of the user associated before sorting the collection**. This has an impact on the performance of the GET endpoint, but this impact is reduced when taking into account that this sort will be used in conjunction with `includes=user` option.

For reference, a benchmark was performed on the impact of this feature, including ~2k datasets created by ~120 different users. The results were the following:

* GET /dataset => **~43.583ms**
* GET /dataset?includes=user => **~65.412ms**
* GET /dataset?includes=user&sort=user.role =>  **~220.010ms** 