### PR TITLE
Fix bug patching dataset without changing dataset apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 24/01/2020
+
+- Fix bug patching dataset without changing dataset apps.
+
 # v1.0.0
 
 ## 14/01/2020

--- a/app/src/routes/api/v1/dataset.router.js
+++ b/app/src/routes/api/v1/dataset.router.js
@@ -504,7 +504,7 @@ const authorizationMiddleware = async (ctx, next) => {
     }
 
     const datasetApps = await DatasetRouter.getDatasetApplications(ctx);
-    if (datasetApps && !DatasetService.validateAppPermission(user, datasetApps)) {
+    if (datasetApps && datasetApps.length > 0 && !DatasetService.validateAppPermission(user, datasetApps)) {
         ctx.throw(403, 'Forbidden - User does not have access to this dataset\'s application'); // if manager or admin but no application -> out
         return;
     }

--- a/app/src/services/dataset.service.js
+++ b/app/src/services/dataset.service.js
@@ -684,7 +684,7 @@ class DatasetService {
 
     static async hasPermission(id, user, datasetApps) {
         let permission = true;
-        if (datasetApps && !DatasetService.validateAppPermission(user, datasetApps)) {
+        if (datasetApps && datasetApps.length > 0 && !DatasetService.validateAppPermission(user, datasetApps)) {
             permission = false;
         }
 

--- a/app/test/e2e/dataset-update.spec.js
+++ b/app/test/e2e/dataset-update.spec.js
@@ -402,6 +402,19 @@ describe('Dataset update tests', () => {
         dataset.should.have.property('application').and.eql(['rw']);
     });
 
+    it('As an ADMIN, editing the dataset without changing the dataset apps should return 200 OK with the updated dataset', async () => {
+        const fakeDataset = await new Dataset(createDataset('cartodb', { application: ['rw'] })).save();
+        const response = await requester
+            .patch(`/api/v1/dataset/${fakeDataset._id}`)
+            .send({ application: ['rw'], loggedUser: USERS.RW_ADMIN });
+
+        response.status.should.equal(200);
+        response.body.should.have.property('data').and.be.an('object');
+        const dataset = deserializeDataset(response);
+        dataset.should.have.property('status').and.equal('saved');
+        dataset.should.have.property('application').and.eql(['rw']);
+    });
+
     afterEach(async () => {
         await Dataset.deleteMany({}).exec();
 


### PR DESCRIPTION
This PR relates to the following PT task:

* https://www.pivotaltracker.com/story/show/170843125

## What does this PR fix?

This PR fixes a problem when PATCHing a dataset without changing the dataset applications (previously returned 403 Forbidden, as described in the PT task above, but it should be allowed).