### PR TITLE
Simplify k8s files and update jenkinsfile for flexible deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,8 +58,6 @@ node {
           sh("kubectl config use-context gke_${GCLOUD_PROJECT}_${GCLOUD_GCE_ZONE}_${KUBE_STAGING_CLUSTER}")
           def service = sh([returnStdout: true, script: "kubectl get deploy ${appName} || echo NotFound"]).trim()
           if ((service && service.indexOf("NotFound") > -1) || (forceCompleteDeploy)){
-            sh("sed -i -e 's/{name}/${appName}/g' k8s/services/*.yaml")
-            sh("sed -i -e 's/{name}/${appName}/g' k8s/staging/*.yaml")
             sh("kubectl apply -f k8s/services/")
             sh("kubectl apply -f k8s/staging/")
           }
@@ -88,11 +86,9 @@ node {
           }
           if (userInput == true && !didTimeout){
             sh("echo Deploying to PROD cluster")
-            sh("kubectl config use-context gke_${GCLOUD_PROJECT}_${GCLOUD_GCE_ZONE}_${KUBE_PROD_CLUSTER}")
+            sh("kubectl config use-context ${KUBECTL_CONTEXT_PREFIX}_${CLOUD_PROJECT_NAME}_${CLOUD_PROJECT_ZONE}_${KUBE_PROD_CLUSTER}")
             def service = sh([returnStdout: true, script: "kubectl get deploy ${appName} || echo NotFound"]).trim()
             if ((service && service.indexOf("NotFound") > -1) || (forceCompleteDeploy)){
-              sh("sed -i -e 's/{name}/${appName}/g' k8s/services/*.yaml")
-              sh("sed -i -e 's/{name}/${appName}/g' k8s/production/*.yaml")
               sh("kubectl apply -f k8s/services/")
               sh("kubectl apply -f k8s/production/")
             }
@@ -109,7 +105,6 @@ node {
           currentBuild.result = "SUCCESS"
       }
     }
-
   } catch (err) {
 
     currentBuild.result = "FAILURE"

--- a/k8s/production/deployment.yaml
+++ b/k8s/production/deployment.yaml
@@ -2,9 +2,9 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    name: {name}
+    name: dataset
     app: rw
-  name: {name}
+  name: dataset
 spec:
   revisionHistoryLimit: 2
   template:
@@ -12,11 +12,11 @@ spec:
       annotations:
         chaos.alpha.kubernetes.io/enabled: "true"
       labels:
-        name: {name}
+        name: dataset
     spec:
       containers:
-      - name: {name}
-        image: vizzuality/{name}
+      - name: dataset
+        image: vizzuality/dataset
         imagePullPolicy: Always
         resources:
           requests:
@@ -35,7 +35,7 @@ spec:
           - name: NODE_PATH
             value: app/src
           - name: LOCAL_URL
-            value: http://{name}.default.svc.cluster.local:3000
+            value: http://dataset.default.svc.cluster.local:3000
           - name: MONGO_URI
             valueFrom:
                 secretKeyRef:

--- a/k8s/production/hpa.yaml
+++ b/k8s/production/hpa.yaml
@@ -1,13 +1,13 @@
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {name}
+  name: dataset
   namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1beta1
     kind: Deployment
-    name: {name}
+    name: dataset
   minReplicas: 5
   maxReplicas: 15
   targetCPUUtilizationPercentage: 50

--- a/k8s/services/service.yaml
+++ b/k8s/services/service.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: {name}
-  name: {name}
+    name: dataset
+  name: dataset
 spec:
   ports:
     - port: 3000
   selector:
-    name: {name}
+    name: dataset

--- a/k8s/staging/deployment.yaml
+++ b/k8s/staging/deployment.yaml
@@ -2,8 +2,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
-    name: {name}
-  name: {name}
+    name: dataset
+  name: dataset
 spec:
   revisionHistoryLimit: 0
   template:
@@ -11,11 +11,11 @@ spec:
       annotations:
         chaos.alpha.kubernetes.io/enabled: "true"
       labels:
-        name: {name}
+        name: dataset
     spec:
       containers:
-      - name: {name}
-        image: vizzuality/{name}
+      - name: dataset
+        image: vizzuality/dataset
         imagePullPolicy: Always
         resources:
           requests:
@@ -34,7 +34,7 @@ spec:
           - name: NODE_PATH
             value: app/src
           - name: LOCAL_URL
-            value: http://{name}.default.svc.cluster.local:3000
+            value: http://dataset.default.svc.cluster.local:3000
           - name: MONGO_URI
             valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
- Update k8s files so that we stop using {name} placeholders
- Update jekinsfile to remove sed calls that replaced the now gone {name} placeholders
- Update jekinsfile with new vars from env allowing a more flexible deployment - single file for AWS and GCP