### PR TITLE
Remove query param usersRole which generated huge pagination links

### DIFF
--- a/app/src/routes/api/v1/dataset.router.js
+++ b/app/src/routes/api/v1/dataset.router.js
@@ -387,6 +387,7 @@ class DatasetRouter {
             delete clonedQuery['page[size]'];
             delete clonedQuery['page[number]'];
             delete clonedQuery.ids;
+            delete clonedQuery.usersRole;
             const serializedQuery = serializeObjToQuery(clonedQuery) ? `?${serializeObjToQuery(clonedQuery)}&` : '?';
             const apiVersion = ctx.mountPath.split('/')[ctx.mountPath.split('/').length - 1];
             const link = `${ctx.request.protocol}://${ctx.request.host}/${apiVersion}${ctx.request.path}${serializedQuery}`;


### PR DESCRIPTION
This PR removes the query param `usersRole` from the generated pagination links which massively increased the size of the pagination links.

This PR is related to the following PT task: https://www.pivotaltracker.com/story/show/170841633