### PR TITLE
Add support for nested filters in dataset's applicationConfig object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 16/03/2020
+
+- Add support for nested filters in applicationConfig object.
+
 # 09/03/2020
 
 - Remove `usersRole` query param which generated huge pagination links.

--- a/app/src/services/dataset.service.js
+++ b/app/src/services/dataset.service.js
@@ -16,6 +16,7 @@ const GraphService = require('services/graph.service');
 const slug = require('slug');
 const { STATUS } = require('app.constants');
 const isUndefined = require('lodash/isUndefined');
+const lodashSet = require('lodash/set');
 
 const stage = process.env.NODE_ENV;
 
@@ -39,20 +40,6 @@ const manualSortAndPaginate = (array, sortedIds, size, page) => {
         total: totalElements,
         docs: manualPaginate(sortedArray, size, page)
     };
-};
-
-const buildCustomObject = (index, value) => {
-    const res = {};
-    res[index] = value;
-    return res;
-};
-
-const buildApplicationConfigFilter = (indexes, value) => {
-    if (indexes.length === 1) {
-        return buildCustomObject(indexes[0], value);
-    }
-
-    return buildCustomObject(indexes[0], buildApplicationConfigFilter(indexes.slice(1), value));
 };
 
 class DatasetService {
@@ -184,7 +171,8 @@ class DatasetService {
                     query.subscribable = { $in: [null, false, {}] };
                 }
             } else if (DatasetService.isApplicationConfigFilter(param)) {
-                query.applicationConfig = buildApplicationConfigFilter(param.split('.').slice(1), query[param]);
+                query.applicationConfig = {};
+                lodashSet(query.applicationConfig, param.split('.').slice(1).join('.'), query[param]);
                 delete query[param];
             }
         });

--- a/app/test/e2e/dataset-get.spec.js
+++ b/app/test/e2e/dataset-get.spec.js
@@ -252,6 +252,32 @@ describe('Get datasets tests', () => {
         datasetIds.should.not.contain(ds4._id);
     });
 
+    it('Getting datasets filtering by dataset fields and by custom fields in the applicationConfig field returns 200 OK response including only datasets that match the filter', async () => {
+        const ds1 = await new Dataset(createDataset('gee')).save();
+        const ds2 = await new Dataset(createDataset('gee', { applicationConfig: { rw: { highlighted: 'false' } } })).save();
+        const ds3 = await new Dataset(createDataset('cartodb', { applicationConfig: { rw: { highlighted: 'true' } } })).save();
+        const ds4 = await new Dataset(createDataset('cartodb', { applicationConfig: { rw: { highlighted: true } } })).save();
+
+        const response1 = await requester.get(`/api/v1/dataset?provider=cartodb&applicationConfig.rw.highlighted=true`);
+        response1.status.should.equal(200);
+        response1.body.should.have.property('data').with.lengthOf(1);
+
+        const datasetIds1 = response1.body.data.map(dataset => dataset.id);
+        datasetIds1.should.not.contain(ds1._id);
+        datasetIds1.should.not.contain(ds2._id);
+        datasetIds1.should.contain(ds3._id);
+        datasetIds1.should.not.contain(ds4._id);
+
+        const response2 = await requester.get(`/api/v1/dataset?provider=gee&applicationConfig.rw.highlighted=false`);
+        response2.status.should.equal(200);
+        response2.body.should.have.property('data').with.lengthOf(1);
+
+        const datasetIds2 = response2.body.data.map(dataset => dataset.id);
+        datasetIds2.should.not.contain(ds1._id);
+        datasetIds2.should.contain(ds2._id);
+        datasetIds2.should.not.contain(ds3._id);
+        datasetIds2.should.not.contain(ds4._id);
+    });
 
     /**
      * We'll want to limit the maximum page size in the future

--- a/app/test/e2e/dataset-get.spec.js
+++ b/app/test/e2e/dataset-get.spec.js
@@ -234,6 +234,24 @@ describe('Get datasets tests', () => {
         datasetIds.should.not.contain(ds4._id);
     });
 
+    it('Getting datasets filtering by custom fields (STRINGS only) in the applicationConfig field returns 200 OK response including only datasets that match the filter', async () => {
+        const ds1 = await new Dataset(createDataset('cartodb')).save();
+        const ds2 = await new Dataset(createDataset('cartodb', { applicationConfig: { rw: { highlighted: 'false' } } })).save();
+        const ds3 = await new Dataset(createDataset('cartodb', { applicationConfig: { rw: { highlighted: 'true' } } })).save();
+        const ds4 = await new Dataset(createDataset('cartodb', { applicationConfig: { rw: { highlighted: true } } })).save();
+
+        const response = await requester.get(`/api/v1/dataset?applicationConfig.rw.highlighted=true`);
+        response.status.should.equal(200);
+        response.body.should.have.property('data').with.lengthOf(1);
+
+        const datasets = deserializeDataset(response);
+        const datasetIds = datasets.map(dataset => dataset.id);
+        datasetIds.should.not.contain(ds1._id);
+        datasetIds.should.not.contain(ds2._id);
+        datasetIds.should.contain(ds3._id);
+        datasetIds.should.not.contain(ds4._id);
+    });
+
 
     /**
      * We'll want to limit the maximum page size in the future


### PR DESCRIPTION
This PR relates to the following PT task: https://www.pivotaltracker.com/n/projects/1883443/stories/171694802

This PR enables filtering datasets by inner properties of the `applicationConfig` object.

This will enable, for instance, setting datasets as highlighted in a particular app, and then fetching those datasets. Check here for a use case scenario: https://www.pivotaltracker.com/story/show/171694802/comments/212372484

**TODO before merging:**
* [ ] Add this new filtering possibility to the docs (waiting for the changes to dataset endpoint docs to be merged).