### PR TITLE
Add informative error message for /:dataset/flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Security update of NPM package `lodash` from 4.17.15 to 4.17.20.
 - Security update of NPM package `yargs-parser` from 13.1.1 to 13.1.2.
 - Security update of NPM package `bl` from 2.2.0 to 2.2.1.
+- Add more informative error message on `/:dataset/flush` 403 response.
 
 # v1.3.2
 

--- a/app/src/routes/api/v1/dataset.router.js
+++ b/app/src/routes/api/v1/dataset.router.js
@@ -506,7 +506,7 @@ const flushAuthorizationMiddleware = async (ctx, next) => {
     }
     // Everyone else is not allowed
     else {
-        ctx.throw(403, 'Forbidden - dataset flush is limited to admin users and dataset owners');
+        ctx.throw(403, 'Forbidden - dataset flush is limited to admin uesrs and dataset owners');
         return;
     }
 }

--- a/app/src/routes/api/v1/dataset.router.js
+++ b/app/src/routes/api/v1/dataset.router.js
@@ -494,16 +494,30 @@ const validationMiddleware = async (ctx, next) => {
     await next();
 };
 
+const flushAuthorizationMiddleware = async (ctx, next) => {
+    logger.info(`[DatasetRouter] Checking authorization for /flush`);
+    const user = DatasetRouter.getUser(ctx);
+    const datasetApps = await DatasetRouter.getDatasetApplications(ctx);
+    const permission = await DatasetService.hasPermission(ctx.params.dataset, user, datasetApps);
+    // Admins and dataset owners can flush
+    if (user.role === 'ADMIN' || permission) {
+        await next();
+        return;
+    }
+    // Everyone else is not allowed
+    else {
+        ctx.throw(403, 'Forbidden - dataset flush is limited to admin uesrs and dataset owners');
+        return;
+    }
+}
+
 const authorizationMiddleware = async (ctx, next) => {
     logger.info(`[DatasetRouter] Checking authorization`);
     // Get user from query (delete) or body (post-patch)
     const newDatasetCreation = ctx.request.path === '/dataset' && ctx.request.method === 'POST';
     const uploadDataset = ctx.request.path.indexOf('upload') >= 0 && ctx.request.method === 'POST';
     const user = DatasetRouter.getUser(ctx);
-    if (ctx.request.path.endsWith('flush') && user.role === 'ADMIN') {
-        await next();
-        return;
-    }
+
     if (user.id === 'microservice') {
         await next();
         return;
@@ -519,8 +533,10 @@ const authorizationMiddleware = async (ctx, next) => {
         }
     }
 
+    // This is technically redundant with the hasPermission check below, since hasPermission
+    // calls validateAppPermission anyway, but leaving here because the error message is informative
     const datasetApps = await DatasetRouter.getDatasetApplications(ctx);
-    if (datasetApps && datasetApps.length > 0 && !DatasetService.validateAppPermission(user, datasetApps)) {
+    if (!DatasetService.validateAppPermission(user, datasetApps)) {
         ctx.throw(403, 'Forbidden - User does not have access to this dataset\'s application'); // if manager or admin but no application -> out
         return;
     }
@@ -580,7 +596,7 @@ router.post('/find-by-ids', validationMiddleware, DatasetRouter.findByIds);
 router.post('/', validationMiddleware, authorizationMiddleware, authorizationBigQuery, DatasetRouter.create);
 // router.post('/', validationMiddleware, authorizationMiddleware, authorizationBigQuery, authorizationSubscribable, DatasetRouter.create);
 router.post('/upload', validationMiddleware, authorizationMiddleware, DatasetRouter.upload);
-router.post('/:dataset/flush', authorizationMiddleware, DatasetRouter.flushDataset);
+router.post('/:dataset/flush', flushAuthorizationMiddleware, DatasetRouter.flushDataset);
 router.post('/:dataset/recover', authorizationRecover, DatasetRouter.recover);
 
 router.get('/:dataset', DatasetRouter.get);

--- a/app/src/routes/api/v1/dataset.router.js
+++ b/app/src/routes/api/v1/dataset.router.js
@@ -506,7 +506,7 @@ const flushAuthorizationMiddleware = async (ctx, next) => {
     }
     // Everyone else is not allowed
     else {
-        ctx.throw(403, 'Forbidden - dataset flush is limited to admin uesrs and dataset owners');
+        ctx.throw(403, 'Forbidden - dataset flush is limited to admin users and dataset owners');
         return;
     }
 }

--- a/app/test/e2e/dataset-flush.spec.js
+++ b/app/test/e2e/dataset-flush.spec.js
@@ -78,7 +78,7 @@ describe('Upload raw data', () => {
 
         response.status.should.equal(403);
         response.body.should.have.property('errors').and.be.an('array');
-        response.body.errors[0].should.have.property('detail').and.equal(`Forbidden`);
+        response.body.errors[0].should.have.property('detail').and.equal(`Forbidden - dataset flush is limited to admin users and dataset owners`);
     });
 
     it('Successfully flush a dataset as an ADMIN', async () => {


### PR DESCRIPTION
- Add informative error message for `/:dataset/flush`: `"Forbidden - dataset flush is limited to admin users and dataset owners"`
- Remove redundant existence check on `validateAppPermission` call
