### PR TITLE
Remove references to grunt since it was removed when migrating to TS.…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ RUN apk update && apk upgrade && \
 
 RUN addgroup $USER && adduser -s /bin/bash -D -G $USER $USER
 
-RUN yarn global add grunt-cli bunyan
-
 RUN mkdir -p /opt/$NAME
 COPY package.json /opt/$NAME/package.json
 COPY yarn.lock /opt/$NAME/yarn.lock

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 case "$1" in
     develop)
         echo "Running Development Server"
-        exec grunt --gruntfile app/Gruntfile.js | bunyan
+        exec yarn watch
         ;;
     test)
         echo "Running Test"


### PR DESCRIPTION
Following the removal of grunt when migrating to TS, the `./dataset.sh develop` command fails. This is due to the `develop` command running grunt.

I have replaced the grunt command with `yarn watch`.