### PR TITLE
Feature/fix local docker setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,6 @@ RUN apk update && apk upgrade && \
 
 RUN addgroup $USER && adduser -s /bin/bash -D -G $USER $USER
 
-RUN yarn global add grunt-cli bunyan
-
 RUN mkdir -p /opt/$NAME
 COPY package.json /opt/$NAME/package.json
 COPY yarn.lock /opt/$NAME/yarn.lock

--- a/dev.env.sample
+++ b/dev.env.sample
@@ -1,2 +1,2 @@
 CT_URL=http://mymachine:9000
-LOCAL_URL=http://mymachine:3000
+LOCAL_URL=http://mymachine:3001

--- a/docker-compose-develop.yml
+++ b/docker-compose-develop.yml
@@ -3,14 +3,16 @@ services:
   develop:
     build: .
     ports:
-      - "3000:3000"
+      - "3001:3001"
     container_name: dataset
     env_file:
       - dev.env
     environment:
-      PORT: 3000
+      PORT: 3001
       NODE_PATH: app/src
       CT_REGISTER_MODE: auto
+      CT_URL: http://mymachine:9000
+      LOCAL_URL: http://mymachine:3001
       CT_TOKEN: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6Im1pY3Jvc2VydmljZSIsImNyZWF0ZWRBdCI6IjIwMTYtMDktMTQifQ.IRCIRm1nfIQTfda_Wb6Pg-341zhV8soAgzw7dd5HxxQ
       API_VERSION: v1
       MONGO_PORT_27017_TCP_ADDR: mongo
@@ -26,7 +28,7 @@ services:
     container_name: dataset-mongo-develop
     command: --smallfiles
     ports:
-      - "27017"
+      - "27020:27017"
     volumes:
-      - $HOME/docker/data/dataset:/data/db
+      - $HOME/docker/data/dataset/mongodb:/data/db
     restart: always

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ set -e
 case "$1" in
     develop)
         echo "Running Development Server"
-        exec grunt --gruntfile app/Gruntfile.js | bunyan
+        exec yarn watch
         ;;
     test)
         echo "Running Test"


### PR DESCRIPTION
I have made a series of small changes which ensures that the microservices build and register with the Control Tower locally with Docker.

The changes to this repo are:
- Remove grunt and bunyan, it was not being used
- Change port so it does not clash with another service
- Update Mongo config